### PR TITLE
fix: 업로드 폼 멤버 input 수정

### DIFF
--- a/components/projects/upload/MemberForm/MemberSearch.tsx
+++ b/components/projects/upload/MemberForm/MemberSearch.tsx
@@ -53,10 +53,10 @@ const StyledContainer = styled.div`
 
   & .search {
     transition: all 0.2s;
-    border: 1.5px solid ${colors.black60};
+    border: 1px solid ${colors.black60};
     border-radius: 6px;
     background: ${colors.black60};
-    padding: 15.5px 20px;
+    padding: 14px 20px;
     color: ${colors.gray100};
 
     &:focus {

--- a/components/projects/upload/MemberForm/MemberSearch.tsx
+++ b/components/projects/upload/MemberForm/MemberSearch.tsx
@@ -52,10 +52,18 @@ const StyledContainer = styled.div`
   ${textStyles.SUIT_14_M};
 
   & .search {
+    transition: all 0.2s;
+    border: 1.5px solid ${colors.black60};
     border-radius: 6px;
     background: ${colors.black60};
     padding: 15.5px 20px;
     color: ${colors.gray100};
+
+    &:focus {
+      outline: none;
+      border-color: ${colors.purple100};
+      background-color: ${colors.black80};
+    }
   }
 
   & .options {

--- a/components/projects/upload/MemberForm/index.tsx
+++ b/components/projects/upload/MemberForm/index.tsx
@@ -227,11 +227,18 @@ const MemberItemWrapper = styled.div`
 const StyledSelect = styled(Select)`
   margin: 0 10px;
   min-width: 200px;
-  height: 100%;
+
+  ${textStyles.SUIT_14_M};
 `;
 
 const StyledInputFormItem = styled(FormItem)`
   width: 100% !important;
+
+  & > input {
+    ${textStyles.SUIT_14_M};
+
+    border-width: 1px;
+  }
 `;
 
 const IconDeleteWrapper = styled.div`

--- a/components/projects/upload/MemberForm/index.tsx
+++ b/components/projects/upload/MemberForm/index.tsx
@@ -227,6 +227,7 @@ const MemberItemWrapper = styled.div`
 const StyledSelect = styled(Select)`
   margin: 0 10px;
   min-width: 200px;
+  height: 100%;
 `;
 
 const StyledInputFormItem = styled(FormItem)`


### PR DESCRIPTION
- close #45 
### 구현 사항
- SOPT 멤버 검색 input focus 상태 수정
- 멤버 폼 내 input 3가지 스타일 맞추기

before
<img width="734" alt="image" src="https://user-images.githubusercontent.com/73823388/190967721-5aec42ad-5d48-421b-8fbe-e09ddc45d8ee.png">

after
<img width="745" alt="image" src="https://user-images.githubusercontent.com/73823388/190967782-b8374f6a-bade-46ba-84db-b4ec947cf6a2.png">

\* SOPT 멤버 검색 input focus 상태로 캡처

### PR Point
[SOPT 멤버 검색 input focus 스타일 수정](6cab97252a0aa093c7d41909c8fea3a8eb0ff254)만 하려다가

[input들끼리 사이즈 다른 게 거슬려서 그것까지 수정](be95e99db2e2e4704a9f36be7fb9df474fa155e6)하고 push 했는데

너무 무책임하게 냅다 height 100% 날려버린 것 같아서

[뭐 때문에 사이즈 달라보이는지 다시 보고 수정](844c433102644046820fc5cb270d8b7be8c260f4)했습니다 ..

<br />

근데 아직 피그마 관련해서 인수인계를 못 받아서 맞는 디자인 버전으로 한 건지 모르겠네욤
<img width="266" alt="image" src="https://user-images.githubusercontent.com/73823388/190968491-c3348996-be72-4406-98d8-62ccbf69c475.png">
이거 보고 했습니다
혹시 문제 있으면 되돌리거나 하겠습니다

<br />

+) 스토리북으로 확인하기 ✨✨ 짱이네요 ! ! ! 괜히 캡처했당